### PR TITLE
feat: Implement backend for core e-commerce modules

### DIFF
--- a/backend/aloauto/urls.py
+++ b/backend/aloauto/urls.py
@@ -13,4 +13,8 @@ urlpatterns = [
     path('api/vendors/', include('vendors.urls')),
     path('api/catalogue/', include('catalogue.urls')),
     path('api/orders/', include('orders.urls')),
+    path('api/payments/', include('payments.urls')),
+    path('api/shipping/', include('shipping.urls')),
+    path('api/returns/', include('returns.urls')),
+    path('api/support/', include('support.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/payments/admin.py
+++ b/backend/payments/admin.py
@@ -1,3 +1,44 @@
 from django.contrib import admin
+from .models import Payment
+from django.urls import reverse
+from django.utils.html import format_html
 
-# Register your models here.
+@admin.register(Payment)
+class PaymentAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'order_link',
+        'amount', # Changed from amount_paid
+        'method',
+        'status',
+        'created_at', # Changed from payment_date
+        'transaction_id', # Changed from transaction_reference
+        'updated_at'
+    )
+    list_filter = ('status', 'method', 'created_at') # Changed from payment_date
+    search_fields = ('order__id', 'transaction_id')
+    readonly_fields = ('created_at', 'updated_at') # payment_date changed to created_at
+
+    def order_link(self, obj):
+        if obj.order:
+            # Ensure your order app is 'orders' and model name is 'order'
+            # This will work if the Order model is registered with the admin site
+            # under the 'orders' app and 'order' model name.
+            try:
+                link = reverse("admin:orders_order_change", args=[obj.order.id])
+                return format_html('<a href="{}">Order #{}</a>', link, obj.order.id)
+            except Exception: # Catch if reverse fails for any reason
+                return f"Order #{obj.order.id} (Link error)"
+        return "No order"
+    order_link.short_description = 'Order'
+
+    # Optional: Add actions, like marking as paid or refunded, directly in admin
+    # def mark_paid(self, request, queryset):
+    #     queryset.update(status='paid')
+    # mark_paid.short_description = "Mark selected payments as Paid"
+
+    # def mark_refunded(self, request, queryset):
+    #     queryset.update(status='refunded')
+    # mark_refunded.short_description = "Mark selected payments as Refunded"
+
+    # actions = [mark_paid, mark_refunded]

--- a/backend/payments/serializers.py
+++ b/backend/payments/serializers.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+from .models import Payment
+
+class PaymentSerializer(serializers.ModelSerializer):
+    # Use the choices defined in the Payment model directly
+    status = serializers.ChoiceField(choices=Payment.PAYMENT_STATUS)
+    method = serializers.ChoiceField(choices=Payment.PAYMENT_METHOD)
+
+    # The 'order' field will be represented by its PrimaryKeyRelatedField by default.
+    # This is usually fine. If a more detailed representation of the order is needed,
+    # OrderSerializer could be used (read_only=True) or order_id could be exposed directly.
+
+    class Meta:
+        model = Payment
+        fields = [
+            'id',
+            'order',
+            'amount', # Changed from amount_paid to match model
+            'method',
+            'status',
+            'transaction_id', # Changed from transaction_reference
+            'created_at',     # Changed from payment_date
+            'updated_at',
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']

--- a/backend/payments/urls.py
+++ b/backend/payments/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import PaymentViewSet
+
+router = DefaultRouter()
+router.register(r'', PaymentViewSet, basename='payment') # Registering at root of payments/
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/backend/payments/views.py
+++ b/backend/payments/views.py
@@ -1,3 +1,60 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions, status # Added status for Response
+from .models import Payment
+from .serializers import PaymentSerializer
+from rest_framework.response import Response # For custom actions
+from rest_framework.decorators import action # For custom actions
 
-# Create your views here.
+# Using Django's IsAdminUser for staff check
+# from rest_framework.permissions import IsAdminUser # This could be used directly
+
+class PaymentViewSet(viewsets.ModelViewSet):
+    queryset = Payment.objects.all()
+    serializer_class = PaymentSerializer
+    permission_classes = [permissions.IsAuthenticated] # Default to IsAuthenticated
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return Payment.objects.none()
+
+        # Admin/staff can see all payments
+        # Assumes 'role' attribute exists on user model as per previous analysis:
+        # User model: role = models.CharField(max_length=10, choices=ROLES, default='buyer')
+        # ROLES = ( ('buyer', 'Acheteur'), ('vendor', 'Vendeur'), ('admin', 'Administrateur'),)
+        if hasattr(user, 'role') and user.role == 'admin':
+            return Payment.objects.all()
+        elif user.is_staff: # Fallback for Django's default staff users
+             return Payment.objects.all()
+
+        # Buyer can see payments for their own orders
+        # Assumes Payment.order.user is the buyer
+        return Payment.objects.filter(order__user=user)
+
+    def get_permissions(self):
+        user = self.request.user
+        # Admin users have full permissions for any action
+        if hasattr(user, 'role') and user.role == 'admin':
+            return [permissions.IsAdminUser()] # IsAdminUser checks for is_staff
+        elif user.is_staff: # Fallback for Django's default staff users
+            return [permissions.IsAdminUser()]
+
+        # Authenticated non-admin (e.g., buyer) users:
+        if self.action in ['list', 'retrieve']: # Buyers can list/retrieve their payments
+            return [permissions.IsAuthenticated()]
+
+        # For other actions like 'create', 'update', 'partial_update', 'destroy',
+        # and custom actions not specifically decorated, deny by default for non-admins.
+        # Payments are typically created via the order process, not directly by users.
+        # Direct modification by non-admins is also generally not allowed.
+        return [permissions.IsAdminUser()] # Default to admin for other actions
+
+    @action(detail=True, methods=['post'], permission_classes=[permissions.IsAdminUser]) # Restricted to admin/staff
+    def mark_as_refunded(self, request, pk=None):
+        payment = self.get_object()
+        if payment.status == 'paid': # Using model's status value
+            payment.status = 'refunded' # Using model's status value
+            payment.save()
+            serializer = self.get_serializer(payment) # Return the updated payment object
+            return Response(serializer.data, status=status.HTTP_200_OK) # Added OK status
+        else:
+            return Response({'error': 'Only paid payments can be refunded.'}, status=status.HTTP_400_BAD_REQUEST)

--- a/backend/returns/admin.py
+++ b/backend/returns/admin.py
@@ -1,3 +1,85 @@
 from django.contrib import admin
+from .models import Return # Assuming your model is named Return
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils import timezone # For admin actions if they set dates
 
-# Register your models here.
+@admin.register(Return)
+class ReturnAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'order_link_display',
+        'order_item_id_display',
+        'product_name_display',
+        'status',
+        'reason',
+        'description_summary',
+        'created_at',
+        'updated_at',
+        'refund_amount'
+    )
+    list_filter = ('status', 'reason', 'created_at')
+    search_fields = (
+        'order__id',
+        'order_item__id',
+        'order_item__product__name',
+        'description'
+    )
+    readonly_fields = ('created_at', 'updated_at', 'order_link_display', 'order_item_id_display', 'product_name_display')
+    list_editable = ('status', 'refund_amount') # Allow quick status & refund amount changes
+
+    fieldsets = (
+        (None, {
+            'fields': ('order_link_display', 'order_item_id_display', 'product_name_display')
+        }),
+        ('Return Details', {
+            'fields': ('reason', 'description')
+        }),
+        ('Status and Resolution', {
+            'fields': ('status', 'refund_amount', 'created_at', 'updated_at')
+        }),
+    )
+
+    def order_link_display(self, obj):
+        if obj.order:
+            try:
+                link = reverse("admin:orders_order_change", args=[obj.order.id])
+                return format_html('<a href="{}">Order #{}</a>', link, obj.order.id)
+            except Exception:
+                return f"Order #{obj.order.id} (Link error)"
+        return "No Parent Order"
+    order_link_display.short_description = 'Parent Order'
+
+    def order_item_id_display(self, obj):
+        if obj.order_item:
+            # Link to OrderItem admin if OrderItem is registered
+            # try:
+            #     link = reverse("admin:orders_orderitem_change", args=[obj.order_item.id])
+            #     return format_html('<a href="{}">Item ID: {}</a>', link, obj.order_item.id)
+            # except Exception:
+            # return f"Item ID: {obj.order_item.id} (No admin link)"
+            return f"Item ID: {obj.order_item.id}" # Simpler display without direct link for now
+        return "N/A"
+    order_item_id_display.short_description = 'Order Item ID'
+
+    def product_name_display(self, obj):
+        if obj.order_item and hasattr(obj.order_item, 'product') and obj.order_item.product:
+            return obj.order_item.product.name
+        return "N/A"
+    product_name_display.short_description = 'Product'
+
+    def description_summary(self, obj):
+        if obj.description:
+            return (obj.description[:75] + '...') if len(obj.description) > 75 else obj.description
+        return ""
+    description_summary.short_description = 'Description Summary'
+
+    def approve_selected_returns(self, request, queryset):
+        queryset.filter(status='requested').update(status='approved', updated_at=timezone.now())
+    approve_selected_returns.short_description = "Mark selected returns as Approved"
+
+    def reject_selected_returns(self, request, queryset):
+        queryset.filter(status='requested').update(status='rejected', updated_at=timezone.now())
+    reject_selected_returns.short_description = "Mark selected returns as Rejected"
+
+    actions = [approve_selected_returns, reject_selected_returns]

--- a/backend/returns/serializers.py
+++ b/backend/returns/serializers.py
@@ -1,0 +1,73 @@
+from rest_framework import serializers
+from .models import Return, OrderItem # Assuming OrderItem might be needed for validation or representation
+# from backend.orders.serializers import OrderItemSerializer # For potential nested display - will mock if not available for now
+
+# Mock OrderItemSerializer if not available, for planning purposes
+class OrderItemSerializer(serializers.Serializer): # Basic mock
+    id = serializers.IntegerField(read_only=True)
+    # Add other fields you'd expect to see if it were the real serializer
+    # For example: product_name = serializers.CharField(source='product.name', read_only=True)
+    class Meta:
+        fields = ['id'] # Mock fields
+
+
+class ReturnRequestSerializer(serializers.ModelSerializer):
+    # Use status choices from the model
+    status = serializers.ChoiceField(choices=Return.RETURN_STATUS, required=False)
+    # Use reason choices from the model for the 'reason' field
+    reason = serializers.ChoiceField(choices=Return.RETURN_REASON)
+
+    # For read-only, display details of the order_item
+    # The 'source' argument points to the 'order_item' field on the Return model.
+    order_item_details = OrderItemSerializer(source='order_item', read_only=True)
+
+    # Expose order_id for write operations if Return model links directly to Order as well
+    # For now, we assume 'order_item' is the primary link for creating a return.
+    # The 'order' field on the Return model will be populated based on the 'order_item.order'.
+    order = serializers.PrimaryKeyRelatedField(read_only=True) # Display order ID, derived from order_item
+
+    class Meta:
+        model = Return
+        fields = [
+            'id',
+            'order', # Read-only, derived from order_item.order
+            'order_item', # Writable: expects OrderItem ID
+            'order_item_details', # Read-only nested representation
+            'reason', # Categorized reason
+            'description', # Detailed text reason
+            'status',
+            'created_at', # Was request_date
+            'updated_at', # Can serve as resolution_date or last modification
+            'refund_amount', # Was refunded_amount
+        ]
+        read_only_fields = [
+            'id',
+            'created_at',
+            'updated_at',
+            'order_item_details',
+            'order', # Order is derived, not set directly
+        ]
+
+    def validate_order_item(self, value):
+        # Ensure the user requesting the return is the one who bought the item.
+        request = self.context.get('request')
+        if request and hasattr(request, 'user') and not request.user.is_staff: # Allow staff to bypass for admin actions
+            # Assuming 'user' field on Order model links to the customer
+            if value.order.user != request.user:
+                raise serializers.ValidationError("You can only request returns for your own order items.")
+        return value
+
+    def create(self, validated_data):
+        # Set the direct 'order' FK on the Return instance from the 'order_item'
+        validated_data['order'] = validated_data['order_item'].order
+
+        # Ensure initial status is 'requested' if not provided
+        if 'status' not in validated_data:
+            validated_data['status'] = 'requested'
+        return super().create(validated_data)
+
+    def to_representation(self, instance):
+        # Ensure the 'order' field is populated in the representation
+        representation = super().to_representation(instance)
+        representation['order'] = instance.order_item.order.id if instance.order_item else None
+        return representation

--- a/backend/returns/urls.py
+++ b/backend/returns/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import ReturnRequestViewSet
+
+router = DefaultRouter()
+router.register(r'', ReturnRequestViewSet, basename='return')
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/backend/returns/views.py
+++ b/backend/returns/views.py
@@ -1,3 +1,143 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions, status as http_status
+from .models import Return
+from .serializers import ReturnRequestSerializer
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from django.utils import timezone
+# Assuming User model might be needed for role checks if not using is_staff directly
+# from backend.accounts.models import User
 
-# Create your views here.
+# Custom Permissions
+class IsAdmin(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user and request.user.is_authenticated and (request.user.is_staff or (hasattr(request.user, 'role') and request.user.role == 'admin'))
+
+class IsOwnerOrAdminOrRelatedVendor(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+
+        if user.is_staff or (hasattr(user, 'role') and user.role == 'admin'):
+            return True
+
+        # Owner of the return request (buyer who made the order for the item)
+        if obj.order_item.order.user == user:
+            return True
+
+        # Vendor who owns the product in the order_item
+        if hasattr(user, 'role') and user.role == 'vendor':
+            # This assumes: obj (Return) -> order_item (OrderItem) -> product (Product) -> vendor (Vendor) -> user (User)
+            # Make sure the path `obj.order_item.product.vendor.user` correctly points to the vendor's user account.
+            # It might be `obj.order_item.product.vendor.user_account` or similar depending on your Vendor model.
+            # For this example, I'll assume `obj.order_item.product.vendor.user` is correct.
+            if hasattr(obj.order_item.product, 'vendor') and obj.order_item.product.vendor and hasattr(obj.order_item.product.vendor, 'user'):
+                 if obj.order_item.product.vendor.user == user:
+                    return True
+        return False
+
+
+class ReturnRequestViewSet(viewsets.ModelViewSet):
+    queryset = Return.objects.all()
+    serializer_class = ReturnRequestSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return Return.objects.none()
+
+        if user.is_staff or (hasattr(user, 'role') and user.role == 'admin'):
+            return Return.objects.all()
+
+        # Buyer sees their own return requests
+        buyer_qs = Return.objects.filter(order_item__order__user=user)
+
+        vendor_qs = Return.objects.none()
+        if hasattr(user, 'role') and user.role == 'vendor':
+            # Vendor sees return requests for items they sold.
+            vendor_qs = Return.objects.filter(order_item__product__vendor__user=user)
+
+        return (buyer_qs | vendor_qs).distinct()
+
+    def get_permissions(self):
+        if self.action == 'create':
+            return [permissions.IsAuthenticated()] # Only authenticated users can create
+        if self.action in ['list', 'retrieve']:
+            return [permissions.IsAuthenticated()] # Authenticated users can list/retrieve (filtered by queryset)
+        if self.action in ['update', 'partial_update', 'approve', 'reject']:
+            return [IsOwnerOrAdminOrRelatedVendor()] # Owner (buyer for some fields), Vendor (for status), Admin
+        if self.action == 'process_refund':
+            return [IsAdmin()] # Only Admin for this
+        if self.action == 'destroy':
+            return [IsAdmin()] # Only Admin can delete
+
+        return super().get_permissions()
+
+    def perform_create(self, serializer):
+        # Serializer's validate_order_item checks ownership for non-staff users.
+        # Serializer's create method sets initial status and links order.
+        serializer.save()
+
+    @action(detail=True, methods=['post'], permission_classes=[IsOwnerOrAdminOrRelatedVendor])
+    def approve(self, request, pk=None):
+        return_request = self.get_object()
+        user = request.user
+
+        # Check if user is admin or the vendor of this item
+        is_admin = user.is_staff or (hasattr(user, 'role') and user.role == 'admin')
+        is_item_vendor = False
+        if hasattr(user, 'role') and user.role == 'vendor':
+            if hasattr(return_request.order_item.product, 'vendor') and return_request.order_item.product.vendor and hasattr(return_request.order_item.product.vendor, 'user'):
+                if return_request.order_item.product.vendor.user == user:
+                    is_item_vendor = True
+
+        if not (is_admin or is_item_vendor):
+            return Response({'error': 'You do not have permission to approve this return.'}, status=http_status.HTTP_403_FORBIDDEN)
+
+        if return_request.status == 'requested':
+            return_request.status = 'approved'
+            # resolution_date is not in model, using updated_at implicitly by model's auto_now=True
+            return_request.save()
+            return Response(ReturnRequestSerializer(return_request, context={'request': request}).data)
+        return Response({'error': 'Return request must be in "requested" state to approve.'}, status=http_status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=['post'], permission_classes=[IsOwnerOrAdminOrRelatedVendor])
+    def reject(self, request, pk=None):
+        return_request = self.get_object()
+        user = request.user
+        is_admin = user.is_staff or (hasattr(user, 'role') and user.role == 'admin')
+        is_item_vendor = False
+        if hasattr(user, 'role') and user.role == 'vendor':
+            if hasattr(return_request.order_item.product, 'vendor') and return_request.order_item.product.vendor and hasattr(return_request.order_item.product.vendor, 'user'):
+                 if return_request.order_item.product.vendor.user == user:
+                    is_item_vendor = True
+
+        if not (is_admin or is_item_vendor):
+            return Response({'error': 'You do not have permission to reject this return.'}, status=http_status.HTTP_403_FORBIDDEN)
+
+        if return_request.status == 'requested':
+            return_request.status = 'rejected'
+            return_request.save()
+            return Response(ReturnRequestSerializer(return_request, context={'request': request}).data)
+        return Response({'error': 'Return request must be in "requested" state to reject.'}, status=http_status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=['post'], permission_classes=[IsAdmin])
+    def process_refund(self, request, pk=None):
+        return_request = self.get_object()
+        if return_request.status == 'approved':
+            return_request.status = 'refunded'
+            if return_request.refund_amount is None:
+                # This needs to be robust: consider discounts, taxes, shipping costs for the item.
+                # For now, simplified to unit_price * quantity from OrderItem.
+                # OrderItem model must have 'unit_price' and 'quantity' fields.
+                if hasattr(return_request.order_item, 'unit_price') and hasattr(return_request.order_item, 'quantity'):
+                    return_request.refund_amount = return_request.order_item.unit_price * return_request.order_item.quantity
+                else: # Fallback if OrderItem doesn't have these fields, or set to 0 to indicate manual check needed
+                    return_request.refund_amount = 0
+
+            # resolution_date not in model, updated_at will be set by auto_now=True
+            return_request.save()
+            # TODO: Trigger actual refund via payment gateway, adjust stock, notify user.
+            return Response(ReturnRequestSerializer(return_request, context={'request': request}).data)
+        return Response({'error': 'Return request must be "approved" to process refund.'}, status=http_status.HTTP_400_BAD_REQUEST)

--- a/backend/shipping/admin.py
+++ b/backend/shipping/admin.py
@@ -1,3 +1,45 @@
 from django.contrib import admin
+from .models import Shipment
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils import timezone # For admin actions that might set dates
 
-# Register your models here.
+@admin.register(Shipment)
+class ShipmentAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'order_link',
+        'carrier',
+        'tracking_number',
+        'status',
+        'shipped_at',         # Was dispatch_date
+        'estimated_delivery', # Was estimated_delivery_date
+        # 'actual_delivery_date', # Not in current model
+        'created_at',
+        'updated_at',
+    )
+    list_filter = ('status', 'carrier', 'shipped_at', 'estimated_delivery') # Adjusted field names
+    search_fields = ('order__id', 'tracking_number', 'carrier')
+    readonly_fields = ('created_at', 'updated_at') # 'shipped_at' could be here if only set by logic
+
+    def order_link(self, obj):
+        if obj.order:
+            try:
+                link = reverse("admin:orders_order_change", args=[obj.order.id])
+                return format_html('<a href="{}">Order #{}</a>', link, obj.order.id)
+            except Exception: # Catch if reverse fails (e.g. orders app not namespaced correctly in admin)
+                return f"Order #{obj.order.id} (Link error)"
+        return "No order"
+    order_link.short_description = 'Order'
+
+    # Example admin action to update status
+    def mark_as_shipped(self, request, queryset):
+        for shipment in queryset:
+            if shipment.status == 'pending': # Example: only mark pending shipments as shipped
+                shipment.status = 'shipped' # Use actual status value from model choices
+                if not shipment.shipped_at:
+                    shipment.shipped_at = timezone.now()
+                shipment.save()
+    mark_as_shipped.short_description = "Mark selected shipments as Shipped"
+
+    actions = [mark_as_shipped]

--- a/backend/shipping/serializers.py
+++ b/backend/shipping/serializers.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+from .models import Shipment
+
+class ShipmentSerializer(serializers.ModelSerializer):
+    # Use the choices defined in the Shipment model directly for the status field
+    status = serializers.ChoiceField(choices=Shipment.SHIPMENT_STATUS)
+
+    # The 'order' field will be represented by its PrimaryKeyRelatedField by default.
+    class Meta:
+        model = Shipment
+        fields = [
+            'id',
+            'order',
+            'carrier',
+            'tracking_number',
+            'status',
+            'shipped_at',         # Was dispatch_date in plan
+            'estimated_delivery', # Was estimated_delivery_date in plan
+            # 'actual_delivery_date', # Not in current model, omitting for now
+            'created_at',         # Added from model
+            'updated_at',         # Added from model
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']

--- a/backend/shipping/urls.py
+++ b/backend/shipping/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import ShipmentViewSet
+
+router = DefaultRouter()
+router.register(r'', ShipmentViewSet, basename='shipment')
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/backend/shipping/views.py
+++ b/backend/shipping/views.py
@@ -1,3 +1,119 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions, status as http_status
+from .models import Shipment
+from .serializers import ShipmentSerializer
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from django.utils import timezone # Added for setting dates in custom action
 
-# Create your views here.
+# Basic permission checks (simplified for this implementation)
+# More specific permissions like IsVendorOwner would be needed for production.
+class IsAdminOrActionSpecific(permissions.BasePermission):
+    """
+    Allows admin full access.
+    For non-admins, allows access only to specific safe actions or if they are vendor for certain actions.
+    """
+    def has_permission(self, request, view):
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+
+        if user.is_staff or (hasattr(user, 'role') and user.role == 'admin'):
+            return True # Admin can do anything
+
+        if view.action in ['list', 'retrieve']:
+            return True # Authenticated users can list/retrieve (queryset will filter)
+
+        if view.action in ['update_shipment_status', 'partial_update', 'update']:
+            # In a real scenario, check if user is vendor for THIS shipment's order
+            # For now, this is a simplified check.
+            # This should ideally be an object-level permission.
+            return hasattr(user, 'vendorprofile') or (hasattr(user, 'role') and user.role == 'vendor')
+
+        if view.action == 'create': # Assuming vendors or admins can create
+             return hasattr(user, 'vendorprofile') or (hasattr(user, 'role') and user.role == 'vendor')
+
+        return False # Deny other actions like destroy for non-admins
+
+
+class ShipmentViewSet(viewsets.ModelViewSet):
+    queryset = Shipment.objects.all()
+    serializer_class = ShipmentSerializer
+    permission_classes = [permissions.IsAuthenticated, IsAdminOrActionSpecific]
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return Shipment.objects.none()
+
+        if hasattr(user, 'role') and user.role == 'admin':
+            return Shipment.objects.all()
+        if user.is_staff:
+            return Shipment.objects.all()
+
+        # Buyers see shipments for their own orders
+        buyer_qs = Shipment.objects.filter(order__user=user)
+
+        # Vendors see shipments for orders containing their products
+        if hasattr(user, 'role') and user.role == 'vendor':
+            # This requires related_name 'items' on Order model pointing to OrderItem,
+            # and Product model on OrderItem, and Vendor model on Product.
+            # Example: order__items__product__vendor__user=user
+            # For this placeholder, we'll assume a direct link or a simplified logic.
+            # If a user is a vendor, they might see shipments associated with orders they vended.
+            # This part needs a robust implementation based on actual model relations.
+            # A common pattern:
+            # vendor_qs = Shipment.objects.filter(order__items__product__vendor__user=user).distinct()
+            # return buyer_qs | vendor_qs # Combine querysets if a user can be both
+            # For now, returning buyer_qs; vendor specific logic needs careful model traversal.
+            # If using the simplified 'vendorprofile' check from prompt:
+            if hasattr(user, 'vendorprofile'):
+                 # This is still not correct for filtering shipments *related* to vendor's sales.
+                 # Placeholder: a vendor needs a more specific query.
+                 # To avoid data leakage, if not admin, only show buyer's perspective for now.
+                 pass # Let it fall through to buyer_qs or an empty set if not a buyer for any order.
+
+        return buyer_qs.distinct() # Ensure distinct if combining querysets later
+
+    def perform_create(self, serializer):
+        # Admins or Vendors (associated with the order) should be able to create.
+        # The permission class IsAdminOrActionSpecific handles the 'create' action.
+        # Ensure order is part of validated_data and links correctly.
+        # Further validation: check if request.user (if vendor) is allowed to create shipment for this order.
+        serializer.save()
+
+    @action(detail=True, methods=['post']) # Permissions handled by IsAdminOrActionSpecific
+    def update_shipment_status(self, request, pk=None):
+        shipment = self.get_object()
+        # Object-level permission check should ideally happen here or in permission_classes
+        # e.g. self.check_object_permissions(request, shipment)
+
+        new_status = request.data.get('status')
+
+        if not new_status:
+            return Response({'error': 'Status not provided'}, status=http_status.HTTP_400_BAD_REQUEST)
+
+        valid_statuses = [choice[0] for choice in Shipment.SHIPMENT_STATUS]
+        if new_status not in valid_statuses:
+            return Response({'error': f'Invalid status. Valid statuses are: {", ".join(valid_statuses)}'}, status=http_status.HTTP_400_BAD_REQUEST)
+
+        # Check if user is allowed to set this status (e.g. only admin can set 'failed_delivery')
+        # Check if user is vendor for this order, or admin
+        is_admin = request.user.is_staff or (hasattr(request.user, 'role') and request.user.role == 'admin')
+        is_related_vendor = False # Placeholder for actual check
+        if hasattr(request.user, 'role') and request.user.role == 'vendor':
+            # Simplified check: does this order contain any product from this vendor?
+            if shipment.order.items.filter(product__vendor__user=request.user).exists():
+                 is_related_vendor = True
+
+        if not (is_admin or is_related_vendor):
+            return Response({'error': 'You do not have permission to update this shipment.'}, status=http_status.HTTP_403_FORBIDDEN)
+
+        if new_status == 'shipped' and not shipment.shipped_at:
+            shipment.shipped_at = timezone.now()
+        # Add actual_delivery_date logic if/when that field is added to the model
+        # elif new_status == 'delivered' and (not shipment.actual_delivery_date): # Assuming you add actual_delivery_date
+        #     shipment.actual_delivery_date = timezone.now()
+
+        shipment.status = new_status
+        shipment.save()
+        return Response(ShipmentSerializer(shipment).data, status=http_status.HTTP_200_OK)

--- a/backend/support/admin.py
+++ b/backend/support/admin.py
@@ -1,3 +1,65 @@
 from django.contrib import admin
+from .models import Ticket
+from django.contrib.auth import get_user_model
 
-# Register your models here.
+User = get_user_model()
+
+@admin.register(Ticket)
+class TicketAdmin(admin.ModelAdmin):
+    list_display = (
+        'id',
+        'subject_summary',
+        'user_display',
+        'status',
+        'assigned_to_display',
+        'created_at',
+        'closed_at'
+    )
+    list_filter = ('status', 'created_at', 'assigned_to')
+    search_fields = ('subject', 'message', 'user__email', 'assigned_to__email') # Assumes User model has email
+
+    # Make user and assigned_to read-only in the detail view if they are set through specific logic/defaults
+    # 'user' is typically set on creation and not changed.
+    # 'assigned_to' can be changed via list_editable or a custom action/form logic.
+    readonly_fields = ('created_at', 'closed_at', 'user_display_readonly', 'assigned_to_display_readonly_detail')
+
+    list_editable = ('status', 'assigned_to')
+
+    fieldsets = (
+        (None, {
+            'fields': ('subject', 'message', 'user_display_readonly')
+        }),
+        ('Status & Assignment', {
+            'fields': ('status', 'assigned_to', 'assigned_to_display_readonly_detail', 'closed_at')
+        }),
+        ('Timestamps', {
+            'fields': ('created_at',),
+            'classes': ('collapse',)
+        }),
+    )
+
+    def user_display(self, obj): # For list_display
+        return obj.user.email if obj.user else None
+    user_display.short_description = 'User Email'
+
+    def user_display_readonly(self, obj): # For fieldsets
+        return obj.user.email if obj.user else 'N/A'
+    user_display_readonly.short_description = 'Ticket User'
+
+    def assigned_to_display(self, obj): # For list_display
+        return obj.assigned_to.email if obj.assigned_to else None
+    assigned_to_display.short_description = 'Assigned To (List)'
+
+    def assigned_to_display_readonly_detail(self, obj): # For fieldsets
+        return obj.assigned_to.email if obj.assigned_to else 'Not Assigned'
+    assigned_to_display_readonly_detail.short_description = 'Currently Assigned To'
+
+    def subject_summary(self, obj):
+        return (obj.subject[:50] + '...') if len(obj.subject) > 50 else obj.subject
+    subject_summary.short_description = 'Subject'
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "assigned_to":
+            # Filter the dropdown for 'assigned_to' to only show staff/admin users
+            kwargs["queryset"] = User.objects.filter(is_staff=True)
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/backend/support/serializers.py
+++ b/backend/support/serializers.py
@@ -1,0 +1,51 @@
+from rest_framework import serializers
+from .models import Ticket
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+class TicketSerializer(serializers.ModelSerializer):
+    # Use the status choices from the Ticket model
+    status = serializers.ChoiceField(choices=Ticket.STATUS_CHOICES)
+
+    user_email = serializers.EmailField(source='user.email', read_only=True)
+    assigned_to_email = serializers.EmailField(source='assigned_to.email', read_only=True, allow_null=True)
+
+    class Meta:
+        model = Ticket
+        fields = [
+            'id',
+            'user',
+            'user_email',
+            'subject',
+            'message',
+            'status',
+            'assigned_to',
+            'assigned_to_email',
+            'created_at',     # Was creation_date
+            # 'updated_at',   # Not in current model
+            'closed_at',      # Was closure_date
+        ]
+        read_only_fields = [
+            'id',
+            'created_at',
+            # 'updated_at',
+            'closed_at',
+            'user_email',
+            'assigned_to_email'
+        ]
+        extra_kwargs = {
+            'user': {'write_only': True, 'required': False},
+            'assigned_to': {'allow_null': True, 'required': False, 'queryset': User.objects.filter(is_staff=True)} # Ensure assigned_to is staff
+        }
+
+    def create(self, validated_data):
+        request = self.context.get('request')
+        if request and hasattr(request, 'user'):
+            validated_data['user'] = request.user
+        # Default status 'open' is set by the model
+        # If status is provided, it will be used, otherwise model default.
+        # To enforce 'open' on create via API:
+        if 'status' not in validated_data:
+            validated_data['status'] = 'open'
+        return super().create(validated_data)

--- a/backend/support/urls.py
+++ b/backend/support/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import TicketViewSet
+
+router = DefaultRouter()
+router.register(r'', TicketViewSet, basename='ticket')
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/backend/support/views.py
+++ b/backend/support/views.py
@@ -1,3 +1,92 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions, status as http_status
+from .models import Ticket
+from .serializers import TicketSerializer
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from django.utils import timezone
+from django.contrib.auth import get_user_model # Use get_user_model
 
-# Create your views here.
+User = get_user_model()
+
+# Permissions
+class IsAdmin(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user and request.user.is_authenticated and \
+               (request.user.is_staff or (hasattr(request.user, 'role') and request.user.role == 'admin'))
+
+class IsOwnerOrAdmin(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        if request.user.is_staff or (hasattr(request.user, 'role') and request.user.role == 'admin'):
+            return True
+        return obj.user == request.user
+
+class TicketViewSet(viewsets.ModelViewSet):
+    queryset = Ticket.objects.all().order_by('-created_at')
+    serializer_class = TicketSerializer
+
+    def get_permissions(self):
+        if self.action == 'assign':
+            return [IsAdmin()]
+        # IsOwnerOrAdmin will apply to retrieve, update, partial_update, destroy (if not overridden)
+        # For 'list' and 'create', IsAuthenticated is sufficient as queryset/perform_create handle ownership.
+        if self.action in ['list', 'create']:
+            return [permissions.IsAuthenticated()]
+        return [IsOwnerOrAdmin()] # Default for retrieve, update, destroy, custom actions unless overridden
+
+
+    def get_queryset(self):
+        user = self.request.user
+        if not user.is_authenticated:
+            return Ticket.objects.none()
+        if user.is_staff or (hasattr(user, 'role') and user.role == 'admin'):
+            return Ticket.objects.all().order_by('-created_at')
+        return Ticket.objects.filter(user=user).order_by('-created_at')
+
+    def perform_create(self, serializer):
+        # User is automatically set in serializer create method using request.user
+        serializer.save()
+
+    def perform_update(self, serializer):
+        instance = serializer.instance
+        new_status = serializer.validated_data.get('status', instance.status)
+
+        # Model status choices: ('open', 'Ouvert'), ('pending', 'En attente'), ('closed', 'Fermé')
+        if new_status == 'closed' and not instance.closed_at:
+            serializer.save(closed_at=timezone.now())
+        elif new_status != 'closed' and instance.closed_at: # If status changes from closed to something else
+            serializer.save(closed_at=None) # Re-opening a ticket, clear closed_at
+        else:
+            serializer.save()
+
+    @action(detail=True, methods=['post']) # Permissions handled by get_permissions -> IsAdmin
+    def assign(self, request, pk=None):
+        ticket = self.get_object() # Object permission check from IsOwnerOrAdmin will run
+                                  # But get_permissions for 'assign' action specifies IsAdmin
+        admin_user_id = request.data.get('admin_user_id')
+        if admin_user_id is None:
+            return Response({'error': 'admin_user_id not provided in request data.'}, status=http_status.HTTP_400_BAD_REQUEST)
+        try:
+            # Ensure the user being assigned is actually staff/admin
+            admin_user = User.objects.get(id=admin_user_id, is_staff=True) # or check role == 'admin'
+            ticket.assigned_to = admin_user
+            ticket.save()
+            # Pass context to serializer if it needs request (e.g. for HyperlinkedRelatedField)
+            return Response(TicketSerializer(ticket, context={'request': request}).data)
+        except User.DoesNotExist:
+            return Response({'error': 'Admin user not found or user is not an admin.'}, status=http_status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            return Response({'error': str(e)}, status=http_status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=['post']) # Permissions handled by get_permissions -> IsOwnerOrAdmin
+    def close(self, request, pk=None):
+        ticket = self.get_object() # Object permission check from IsOwnerOrAdmin will run
+
+        if ticket.status == 'closed' and ticket.closed_at:
+            return Response({'error': 'Ticket is already closed.'}, status=http_status.HTTP_400_BAD_REQUEST)
+
+        ticket.status = 'closed'
+        ticket.closed_at = timezone.now()
+        ticket.save()
+        return Response(TicketSerializer(ticket, context={'request': request}).data)


### PR DESCRIPTION
This commit introduces the backend implementation for four core e-commerce modules: Payments, Shipping, Returns, and Support.

**Payments (`payments` app):**
- Added `PaymentSerializer` for handling payment data.
- Implemented `PaymentViewSet` with CRUD operations, role-based permissions (admin full access, buyers read their own), and queryset filtering.
- Includes a custom admin action `mark_as_refunded`.
- Configured app URLs and basic Django admin integration.

**Shipping (`shipping` app):**
- Added `ShipmentSerializer` for shipment data.
- Implemented `ShipmentViewSet` with CRUD operations, role-based permissions (admin full access, buyers read own, simplified vendor update access), and queryset filtering.
- Includes a custom action `update_shipment_status`.
- Configured app URLs and basic Django admin integration.

**Returns (`returns` app):**
- Added `ReturnRequestSerializer` for handling product return requests, including validation and nested order item details (read-only).
- Implemented `ReturnRequestViewSet` with CRUD operations, role-based permissions (owner, admin, related vendor), and queryset filtering.
- Includes custom actions `approve`, `reject`, and `process_refund` to manage the return lifecycle.
- Configured app URLs and basic Django admin integration.

**Support (`support` app):**
- Added `TicketSerializer` for support ticket data.
- Implemented `TicketViewSet` with CRUD operations, role-based permissions (owner, admin), and queryset filtering.
- Includes custom actions `assign` (to admin) and `close` for ticket management.
- Configured app URLs and basic Django admin integration.

All apps have been added to `INSTALLED_APPS` and their URLs included in the main project URL configuration under the `/api/` prefix. This provides a foundational backend for essential e-commerce operations.