### PR TITLE
Fix Celery settings module

### DIFF
--- a/backend/aloauto/celery.py
+++ b/backend/aloauto/celery.py
@@ -2,8 +2,8 @@ import os
 from celery import Celery
 
 # Set the default Django settings module for the 'celery' program.
-# Replace 'backend.aloauto.settings' with your actual project settings module
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.aloauto.settings')
+# Use the same settings module as manage.py
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'aloauto.settings')
 
 app = Celery('aloauto') # Replace 'aloauto' with your project's name if different
 


### PR DESCRIPTION
## Summary
- make Celery use `aloauto.settings`

## Testing
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_683f7d2a01dc8326834270e93acd2c00