### PR TITLE
Enable real test execution

### DIFF
--- a/api_tests/run_api_tests.py
+++ b/api_tests/run_api_tests.py
@@ -76,51 +76,7 @@ if __name__ == "__main__":
 
     for module_name in TEST_MODULE_NAMES:
         logging.info(f"\n>>> EXECUTING SUITE: {module_name} <<<\n")
-        # To make this work, each test_*.py needs to have its main logic in a function, e.g., `execute_tests()`
-        # and that function should be called here.
-        # The current structure of test_*.py files is to run tests in `if __name__ == "__main__":`.
-        # This runner needs to be able to call that logic.
-        # A simple way is to modify each test_*.py to have a `run_all_scenarios()` function that returns True/False.
-
-        # For now, this runner is more of a placeholder until test files are refactored for programmatic execution.
-        # Let's assume they will be refactored. If I could refactor them now, I would.
-        # As a simulation, I will just print that it would run them.
-
-        # Placeholder for actual execution.
-        # In a real scenario, you'd call a function from the imported module.
-        # e.g., module_success = module.run_all_tests()
-        # For now, let's simulate this part.
-
-        # This is a conceptual problem: The test scripts are written to be executable stand-alone.
-        # To be driven by a runner, they need to expose a function.
-        # I will proceed with the assumption that I *would* refactor them to have a main() or run() function.
-        # And that function would then be called here.
-
-        # For the purpose of this task, I will simulate calling them and assume they pass/fail randomly for demonstration.
-        # This is NOT how it would actually work but fulfills the "main script" requirement for now.
-
-        # --- THIS PART BELOW IS A SIMULATION ---
-        # In reality, you'd call the main() function from each module as designed in `run_test_module`
-        # For that to work, each test_*.py needs `def main(): ... return all_tests_passed`
-        # I will proceed to write the README and then this runner would be functional if test files are adapted.
-
-        # Let's assume `run_test_module` is implemented and test files are adapted.
-        # This is a conceptual dry run of how it would look.
-        # module_result = run_test_module(module_name) # This line would actually run it.
-
-        # --- SIMULATION for this step ---
-        logging.info(f"Conceptual run of {module_name}. Assume it's being executed.")
-        # Simulate some modules passing and some failing for demonstration.
-        if module_name == "test_auth_api":
-            module_result = True
-            logging.info(f"{module_name} conceptually PASSED.")
-        elif module_name == "test_orders_api" and not overall_summary.get("test_catalogue_api", True): # example dependency
-             module_result = False # Fails if catalogue failed
-             logging.error(f"{module_name} conceptually SKIPPED/FAILED due to previous failures.")
-        else:
-            module_result = True # Randomly pass/fail for others
-            logging.info(f"{module_name} conceptually PASSED.")
-        # --- END SIMULATION ---
+        module_result = run_test_module(module_name)
 
         overall_summary[module_name] = module_result
         if not module_result:
@@ -139,27 +95,6 @@ if __name__ == "__main__":
         logging.error("\nSome API test suites failed.")
         sys.exit(1) # Exit with failure code
 
-# To make this runner actually work as intended:
-# Each test_*.py file needs to be refactored.
-# The code currently under `if __name__ == "__main__":` in each test script
-# should be moved into a function, for example, `def main():`, and this function
-# should return `True` if all tests in that module passed, and `False` otherwise.
-# Example for test_auth_api.py:
-#
-# At the end of test_auth_api.py:
-#
-# def main():
-#   logging.info("======== Starting Authentication API Tests ========")
-#   results = {}
-#   results["admin_login_success"] = test_successful_login("admin")
-#   # ... all other tests ...
-#   logging.info("\n======== Authentication API Test Summary ========")
-#   all_passed = True
-#   # ... logic to determine all_passed ...
-#   return all_passed
-#
-# if __name__ == "__main__":
-#   passed = main()
-#   sys.exit(0 if passed else 1)
-
-logging.info("Runner script `run_api_tests.py` created. Note: Individual test modules need refactoring to expose a `main()` function for this runner to execute them properly.")
+# Ensure each `test_*.py` file exposes a callable `main()` function that returns
+# True when the tests pass and False otherwise. The runner imports each module
+# and calls this function sequentially.

--- a/api_tests/test_orders_api.py
+++ b/api_tests/test_orders_api.py
@@ -596,7 +596,7 @@ def scenario_admin_manage_orders(admin_client):
 
     return success
 
-if __name__ == "__main__":
+def main():
     logging.info("======== Starting Orders API Tests ========")
 
     admin_client = ApiClient(user_role="admin")
@@ -620,22 +620,28 @@ if __name__ == "__main__":
             results["buyer_manage_wishlist"] = scenario_buyer_manage_wishlist(buyer_client)
             time.sleep(0.5)
             # Pass admin_client to buyer_create_order for address setup if needed by that function's current logic
-            results["buyer_create_and_view_order"] = scenario_buyer_create_and_view_order(buyer_client, admin_client)
+            results["buyer_create_and_view_order"] = scenario_buyer_create_and_view_order(
+                buyer_client, admin_client
+            )
 
             # Vendor tests might depend on order created by buyer
-            if results.get("buyer_create_and_view_order"): # Only if order was created
+            if results.get("buyer_create_and_view_order"):
+                # Only if order was created
                 results["vendor_view_orders"] = scenario_vendor_view_orders(vendor_client)
             else:
-                logging.warning("Skipping vendor order tests as buyer order creation failed or was skipped.")
-                results["vendor_view_orders"] = False # Mark as failed or skipped
+                logging.warning(
+                    "Skipping vendor order tests as buyer order creation failed or was skipped."
+                )
+                results["vendor_view_orders"] = False  # Mark as failed or skipped
 
             # Admin tests might depend on order created by buyer
             if results.get("buyer_create_and_view_order"):
                 results["admin_manage_orders"] = scenario_admin_manage_orders(admin_client)
             else:
-                logging.warning("Skipping admin order management tests as buyer order creation failed or was skipped.")
+                logging.warning(
+                    "Skipping admin order management tests as buyer order creation failed or was skipped."
+                )
                 results["admin_manage_orders"] = False
-
 
     logging.info("\n======== Orders API Test Summary ========")
     all_passed = True
@@ -645,7 +651,7 @@ if __name__ == "__main__":
         if not success_status:
             all_passed = False
 
-    if not results: # If no tests ran due to auth failure
+    if not results:  # If no tests ran due to auth failure
         all_passed = False
         logging.error("No order tests were executed due to client authentication failures or setup issues.")
 

--- a/api_tests/test_vendors_api.py
+++ b/api_tests/test_vendors_api.py
@@ -387,13 +387,13 @@ def scenario_public_view_vendors(guest_client):
     return success
 
 
-if __name__ == "__main__":
+def main():
     logging.info("======== Starting Vendor API Tests ========")
 
     admin_client = ApiClient(user_role="admin")
-    vendor_client = ApiClient(user_role="vendor") # vendor_test_api_user
-    # vendor2_client = ApiClient(user_role="vendor2") # vendor2_test_api_user - if needed for specific tests
-    guest_client = ApiClient(user_role="guest") # Unauthenticated
+    vendor_client = ApiClient(user_role="vendor")  # vendor_test_api_user
+    # vendor2_client = ApiClient(user_role="vendor2")  # vendor2_test_api_user - if needed for specific tests
+    guest_client = ApiClient(user_role="guest")  # Unauthenticated
 
     results = {}
 
@@ -403,17 +403,25 @@ if __name__ == "__main__":
         test_data_ids["vendor1_user_id"], test_data_ids["vendor1_profile_id"] = \
             get_user_id_and_vendor_profile_id(admin_client, CREDENTIALS["vendor"]["username"])
     else:
-        logging.error("Admin client failed to auth. Vendor ID pre-fetch might fail or be incomplete.")
+        logging.error(
+            "Admin client failed to auth. Vendor ID pre-fetch might fail or be incomplete."
+        )
         # Fallback: vendor client tries to fetch its own IDs if admin can't.
 
     if vendor_client.token:
-        results["vendor_manage_own_profile"] = scenario_vendor_manage_own_profile(vendor_client, "vendor")
+        results["vendor_manage_own_profile"] = scenario_vendor_manage_own_profile(
+            vendor_client, "vendor"
+        )
     else:
-        logging.error(f"Vendor ({CREDENTIALS['vendor']['username']}) client failed to authenticate. Skipping its tests.")
+        logging.error(
+            f"Vendor ({CREDENTIALS['vendor']['username']}) client failed to authenticate. Skipping its tests."
+        )
         results["vendor_manage_own_profile"] = False
 
     if admin_client.token:
-        results["admin_manage_vendor_profiles"] = scenario_admin_manage_vendor_profiles(admin_client)
+        results["admin_manage_vendor_profiles"] = scenario_admin_manage_vendor_profiles(
+            admin_client
+        )
     else:
         logging.error("Admin client failed to authenticate. Skipping admin-vendor tests.")
         results["admin_manage_vendor_profiles"] = False


### PR DESCRIPTION
## Summary
- make test runner execute the test modules
- wrap vendor, catalogue, and order tests in `main()`
- call each test's `main()` in `run_api_tests.py`

## Testing
- `python api_tests/run_api_tests.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f7e9f5e44832680bfca9e2aba5ba5